### PR TITLE
Update Builder.php

### DIFF
--- a/src/Soql/Builder.php
+++ b/src/Soql/Builder.php
@@ -72,7 +72,7 @@ class Builder
         foreach ($where as $key => $val) {
             if (is_int($key)) {
                 $where[$key] = $val;
-            } elseif (is_string($val) && !strtotime($val)) {
+            } elseif (is_string($val) && strtotime($val) < 1) {
                 $where[$key] = "$key='$val'";
             } elseif (is_bool($val)) {
                 $where[$key] = $key . '=' . ($val ? 'TRUE' : 'FALSE');


### PR DESCRIPTION
In line 75 strtotime() evaluates to negative timestamp for some strings (ex.: 0063A0000181Fpl, 0063A0000181Fby) and this part of the "elseif" does not get executed, so in case someone wants to send in an ID using the soqlBuilder, it will get an error from Salesforce, because Salesforce only accepts ID's as strings. If this "elseif" part (line 75) does not evaluate to true, teh string won't get wrapped in single quotes and the request fails.